### PR TITLE
include the syslog-ng-http

### DIFF
--- a/syslog-ng-splunk-hec-install.sh
+++ b/syslog-ng-splunk-hec-install.sh
@@ -71,7 +71,7 @@ install_syslog_ng() {
             apt-get update
             apt-get install -y syslog-ng
         elif command -v yum >/dev/null 2>&1; then
-            yum install -y syslog-ng
+            yum install -y syslog-ng syslog-ng-http
         else
             log "Error: Unsupported package manager"
             exit 1


### PR DESCRIPTION
Yum to install the syslog-ng-http module.
This was not installed by default in the Amazon AWS Linux system with syslog-ng

I was getting an error of:

```log
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: Error parsing config, syntax error, unexpected LL_IDENTIFIER, expecting '}' in /etc/syslog-ng/syslog-ng.conf:26:5-26:9:
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 21 source s_network {
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 22 network(ip("0.0.0.0") transport("udp") port(514));
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 23 };
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 24 # Splunk HEC Destination
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 25 destination d_splunk_hec {
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 26----> http(
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 26----> ^^^^
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 27 url("https://hec.huntress.io/services/collector")
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 28 method("POST")
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 29 headers("Authorization: Splunk xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx")
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 30 body('$(format-json time="${ISODATE}" host="${HOST}" source="${PROGRAM}" sourcetype="syslog" index="main" even>
Apr 11 04:02:38 ip-10-0-0-19.ap-southeast-2.compute.internal syslog-ng[2879844]: 31 timeout(10)
```

I was able to track down that the module http was not included by grepping the module, and noticing that the module was not installed.

`sudo syslog-ng --module-registry | grep http`

Unsure if the debian based OSs would also need to have this explictly called as well.